### PR TITLE
Add `grepn` function

### DIFF
--- a/dotfiles/bash/.bash_aliases
+++ b/dotfiles/bash/.bash_aliases
@@ -96,6 +96,28 @@ copydate() {
     echo "$formatted_date" | setclip
 }
 
+# Keep the first n(default to 1) lines and pass the rest through grep
+grepn () {
+    num_lines=1
+
+    # Parse flags to extract -n
+    if [[ "$1" =~ -n(=.+)? ]]; then
+        if [[ "$1" == *=* ]]; then
+            num_lines="${1#*=}"
+        else
+            shift
+            num_lines=$1
+        fi
+        if [[ ! $num_lines =~ [0-9]+ ]]; then
+            echo "Invalid number of lines: ${num_lines}";
+            return -1
+        fi
+        shift
+    fi
+
+    tee >(head -n $num_lines) >(tail -n +$((1+$num_lines)) | grep "$@") >/dev/null
+}
+
 # Connect a SOCKS proxy
 # TODO: Allow passing through the -D option
 alias connect_socks="ssh -D 1080 -fnN"

--- a/dotfiles/bash/.bash_aliases
+++ b/dotfiles/bash/.bash_aliases
@@ -115,10 +115,11 @@ grepn () {
         shift
     fi
 
-    {
-        for (( i=0; i < num_lines; i++)); do IFS= read -r line; printf '%s\n' "$line"; done
-        grep "$@"
-    }
+    for (( i=0; i < num_lines; i++ )); do
+        IFS= read -r line
+        printf '%s\n' "$line"
+    done
+    grep "$@"
 }
 
 # Connect a SOCKS proxy

--- a/dotfiles/bash/.bash_aliases
+++ b/dotfiles/bash/.bash_aliases
@@ -115,7 +115,10 @@ grepn () {
         shift
     fi
 
-    tee >(head -n $num_lines) >(tail -n +$((1+$num_lines)) | grep "$@") >/dev/null
+    {
+        for (( i=0; i < num_lines; i++)); do IFS= read -r line; printf '%s\n' "$line"; done
+        grep "$@"
+    }
 }
 
 # Connect a SOCKS proxy


### PR DESCRIPTION
A convenient way to pipe a command that outputs data with a header and grep the table (but not the header). Defaults to n=1, but if you have a multi-line header you can use `grepn -n $num_lines pattern`.